### PR TITLE
Avoid trying to access non existent array key

### DIFF
--- a/Classes/Processing/DataToPaginatedData.php
+++ b/Classes/Processing/DataToPaginatedData.php
@@ -16,7 +16,7 @@ class DataToPaginatedData {
     ) {
         $paginationSettings = $processorConfiguration['pagination.'];
         $uniquePaginatorId = $cObj->stdWrapValue('uniqueId', $paginationSettings ?? []);
-        $uniquePaginatorIdKey = $cObj->getRequest()->getQueryParams()['paginatorId'];
+        $uniquePaginatorIdKey = $cObj->getRequest()->getQueryParams()['paginatorId'] ?? null;
         if($uniquePaginatorId == $uniquePaginatorIdKey) {
             $currentPage = (int)$cObj->getRequest()->getQueryParams()['paginationPage'] ? : 1;
         } else {


### PR DESCRIPTION
Use null coalescing operator to avoid error on non existing array key.
The error occured when accessing a page with a record containing 
the processor without pagination data inside of the url.